### PR TITLE
feat: add `kittysay::print` function to wrap the `kittysay::generate` fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,3 +111,7 @@ pub fn generate(message: &str, format_opts: &FormatOptions) -> String {
 		chars.arrow,
 	)
 }
+
+pub fn print(message: &str, format_opts: &FormatOptions) -> String {
+	format!("{}{}", generate(message, &format_opts), KITTY)
+}


### PR DESCRIPTION
kitty can currently be called like this:
```rust
use kittysay::{KITTY, generate};

pub fn main() {
  let format_opts = FormatOpts {
    think: false,
    width: 80,
  };
  println!(format!("{}{}", generate("<3", format_opts), KITTY));
}
```

or we could add a `kittysay::print` fn:
```rust
pub fn print(message: &str, format_opts: &FormatOptions) -> String {
  format!("{}{}", generate(message, &format_opts), KITTY)
}
```